### PR TITLE
ci(workflows): publish legacy PR status contexts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+  statuses: write
+
 jobs:
   dependency-scan:
     runs-on: ubuntu-latest
@@ -57,3 +61,36 @@ jobs:
           OPENAI_API_KEY: "dummy-ci-key"
         run: |
           pytest -q
+
+  legacy-status:
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    needs: [dependency-scan, test]
+    steps:
+      - name: Publish legacy commit status
+        uses: actions/github-script@v7
+        env:
+          DEPENDENCY_SCAN_RESULT: ${{ needs.dependency-scan.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+        with:
+          script: |
+            const results = [
+              process.env.DEPENDENCY_SCAN_RESULT,
+              process.env.TEST_RESULT,
+            ];
+            const state = results.every((result) => result === 'success')
+              ? 'success'
+              : 'failure';
+            const description = state === 'success'
+              ? 'CI workflow checks passed'
+              : `CI workflow checks did not pass (${results.join(', ')})`;
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.pull_request.head.sha,
+              state,
+              context: 'legacy/ci',
+              description,
+              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions:
+  contents: read
+  statuses: write
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -45,3 +49,30 @@ jobs:
           name: frontend-coverage
           path: frontend/coverage/
           if-no-files-found: ignore
+
+  legacy-status:
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - name: Publish legacy commit status
+        uses: actions/github-script@v7
+        env:
+          TEST_RESULT: ${{ needs.test.result }}
+        with:
+          script: |
+            const result = process.env.TEST_RESULT;
+            const state = result === 'success' ? 'success' : 'failure';
+            const description = state === 'success'
+              ? 'Frontend test workflow checks passed'
+              : `Frontend test workflow checks did not pass (${result})`;
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.pull_request.head.sha,
+              state,
+              context: 'legacy/frontend-tests',
+              description,
+              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });


### PR DESCRIPTION
## Summary
Add explicit legacy commit status contexts for pull request workflows so GitHub's older combined commit-status endpoint no longer reports `pending` with no contexts while Actions check runs are green.

## What changed
- add `statuses: write` permissions to the PR workflows
- add an always-running final status job to `.github/workflows/ci.yml` that publishes `legacy/ci`
- add an always-running final status job to `.github/workflows/frontend-tests.yml` that publishes `legacy/frontend-tests`
- use the pull request head SHA so the legacy contexts attach to the actual PR commit

## Why
The repository currently emits GitHub Actions check runs only. Older consumers of the combined commit-status endpoint see no contexts and report a stale `pending` state even when the real checks have completed successfully.

## Notes
- existing workflow jobs and check runs are unchanged
- this is additive compatibility behavior for legacy status consumers
- no application code changes are included in this PR