### PR TITLE
ci(release-please): ignore coverage badge-only commits

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,83 +1,86 @@
 {
-    "packages": {
-        ".": {
-            "release-type": "simple",
-            "changelog-path": "CHANGELOG.md"
-        },
-        "backend": {
-            "release-type": "python",
-            "package-name": "backend",
-            "changelog-path": "CHANGELOG.md",
-            "extra-files": [
-                {
-                    "type": "generic",
-                    "path": "version.py"
-                }
-            ]
-        },
-        "frontend": {
-            "release-type": "simple",
-            "package-name": "frontend",
-            "changelog-path": "CHANGELOG.md",
-            "extra-files": [
-                {
-                    "type": "json",
-                    "path": "version.json",
-                    "jsonpath": "$.version"
-                }
-            ]
-        }
+  "packages": {
+    ".": {
+      "release-type": "simple",
+      "changelog-path": "CHANGELOG.md",
+      "exclude-paths": [
+        "coverage_badge.svg"
+      ]
     },
-    "pull-request-title-pattern": "chore${scope}: release${component} ${version}",
-    "labels": [
-        "release",
-        "autorelease: pending"
-    ],
-    "changelog-types": [
+    "backend": {
+      "release-type": "python",
+      "package-name": "backend",
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
         {
-            "type": "feat",
-            "section": "Features",
-            "hidden": false
-        },
-        {
-            "type": "fix",
-            "section": "Bug Fixes",
-            "hidden": false
-        },
-        {
-            "type": "perf",
-            "section": "Performance",
-            "hidden": false
-        },
-        {
-            "type": "refactor",
-            "section": "Refactors",
-            "hidden": false
-        },
-        {
-            "type": "docs",
-            "section": "Docs",
-            "hidden": false
-        },
-        {
-            "type": "test",
-            "section": "Tests",
-            "hidden": false
-        },
-        {
-            "type": "ci",
-            "section": "CI",
-            "hidden": false
-        },
-        {
-            "type": "build",
-            "section": "Build",
-            "hidden": false
-        },
-        {
-            "type": "chore",
-            "section": "Chores",
-            "hidden": false
+          "type": "generic",
+          "path": "version.py"
         }
-    ]
+      ]
+    },
+    "frontend": {
+      "release-type": "simple",
+      "package-name": "frontend",
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "version.json",
+          "jsonpath": "$.version"
+        }
+      ]
+    }
+  },
+  "pull-request-title-pattern": "chore${scope}: release${component} ${version}",
+  "labels": [
+    "release",
+    "autorelease: pending"
+  ],
+  "changelog-types": [
+    {
+      "type": "feat",
+      "section": "Features",
+      "hidden": false
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes",
+      "hidden": false
+    },
+    {
+      "type": "perf",
+      "section": "Performance",
+      "hidden": false
+    },
+    {
+      "type": "refactor",
+      "section": "Refactors",
+      "hidden": false
+    },
+    {
+      "type": "docs",
+      "section": "Docs",
+      "hidden": false
+    },
+    {
+      "type": "test",
+      "section": "Tests",
+      "hidden": false
+    },
+    {
+      "type": "ci",
+      "section": "CI",
+      "hidden": false
+    },
+    {
+      "type": "build",
+      "section": "Build",
+      "hidden": false
+    },
+    {
+      "type": "chore",
+      "section": "Chores",
+      "hidden": false
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
Stop Release Please from treating coverage badge-only updates as release-worthy changes.

## What changed
- add `exclude-paths: ["coverage_badge.svg"]` to the root package config in `release-please-config.json`

## Why
The coverage badge workflow can auto-commit `coverage_badge.svg` on pushes to `main`. Without an exclude rule, Release Please can treat that badge-only `chore` commit as release noise and generate unnecessary release activity or changelog entries.

## Scope
- targeted to badge-only updates at the repository root
- does not hide other `chore` commits globally
- does not change the coverage workflow behavior itself